### PR TITLE
Update Database Configuration from SQLite3 to PostgreSQL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ ruby "3.2.2"
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.2"
 
-# Use sqlite3 as the database for Active Record
-gem "sqlite3", "~> 1.4"
+# Use psql as the database for Active Record
+gem "pg"
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,7 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
+    pg (1.5.4)
     polars-df (0.6.0-aarch64-linux)
     polars-df (0.6.0-arm64-darwin)
     polars-df (0.6.0-x86_64-linux)
@@ -206,9 +207,6 @@ GEM
       faraday-multipart (>= 1)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    sqlite3 (1.6.8-aarch64-linux)
-    sqlite3 (1.6.8-arm64-darwin)
-    sqlite3 (1.6.8-x86_64-linux)
     stringio (3.0.9)
     thor (1.3.0)
     tiktoken_ruby (0.0.6-aarch64-linux)
@@ -235,11 +233,11 @@ DEPENDENCIES
   dotenv-rails
   matrix
   pdf-reader
+  pg
   polars-df (~> 0.6.0)
   puma (>= 5.0)
   rails (~> 7.1.2)
   ruby-openai
-  sqlite3 (~> 1.4)
   tiktoken_ruby (~> 0.0.6)
   tzinfo-data
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,21 @@
-# SQLite. Versions 3.8.0 and up are supported.
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem "sqlite3"
-#
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
 development:
   <<: *default
-  database: storage/development.sqlite3
+  database: happiness-hypothesis-development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: storage/test.sqlite3
+  database: happiness-hypothesis-test
 
 production:
   <<: *default
-  database: storage/production.sqlite3
+  database: happiness-hypothesis-production
+  username: happiness-hypothesis-admin
+  password: <%= ENV['HAPPINESS_HYPOTHESIS_DATABASE_PASSWORD'] %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_19_133335) do
+ActiveRecord::Schema[7.1].define(version: 20_231_119_133_335) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "questions", force: :cascade do |t|
     t.string "question", limit: 140
     t.text "context"
-    t.text "answer", limit: 1000
+    t.text "answer"
     t.integer "ask_count", default: 1
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
-
 end


### PR DESCRIPTION
### Overview
This pull request updates our Rails application's database configuration, transitioning from SQLite3 to PostgreSQL. This change aims to enhance the application's scalability and compatibility with deployment environments, as PostgreSQL is better suited for production-level applications.

### Changes Made
- Updated `Gemfile` to use PostgreSQL (`pg` gem) instead of SQLite3.
- Included the specific version of the `pg` gem (`1.5.4`) in `Gemfile.lock`.
- Modified `config/database.yml` to set PostgreSQL as the default database adapter.
- Updated database configurations for `development`, `test`, and `production` environments to reflect the change to PostgreSQL.
- Removed SQLite3 configurations and comments from `config/database.yml`.

### Justification
Switching to PostgreSQL offers several advantages:
- **Scalability:** PostgreSQL handles larger volumes of data more efficiently, which is crucial as our application grows.
- **Compatibility:** Most cloud hosting services favor PostgreSQL, making this switch necessary for smoother deployment.
- **Advanced Features:** PostgreSQL provides more advanced features than SQLite3, which could be beneficial as we expand the application's functionalities.